### PR TITLE
proprietary-files: move libsdedrm to Display-Hardware section

### DIFF
--- a/helpers/lists/proprietary/DRM
+++ b/helpers/lists/proprietary/DRM
@@ -17,7 +17,6 @@ vendor/lib/libops.so
 vendor/lib/libqisl.so
 vendor/lib/librmp.so
 vendor/lib/librpmb.so
-vendor/lib/libsdedrm.so
 vendor/lib/libsecureui.so
 vendor/lib/libsecureui_svcsock.so
 vendor/lib/libsi.so
@@ -43,7 +42,6 @@ vendor/lib64/libprdrmdecrypt.so
 vendor/lib64/libqisl.so
 vendor/lib64/librmp.so
 vendor/lib64/librpmb.so
-vendor/lib64/libsdedrm.so
 vendor/lib64/libsecureui.so
 vendor/lib64/libsecureui_svcsock.so
 vendor/lib64/libsi.so

--- a/helpers/lists/proprietary/Display-Hardware
+++ b/helpers/lists/proprietary/Display-Hardware
@@ -9,6 +9,7 @@ vendor/lib/libgrallocutils.so
 vendor/lib/libqdMetaData.so
 vendor/lib/libqdutils.so
 vendor/lib/libqservice.so
+vendor/lib/libsdedrm.so
 vendor/lib/libsdm-colormgr-algo.so
 vendor/lib/libsdmcore.so
 vendor/lib/libsdmextension.so
@@ -24,6 +25,7 @@ vendor/lib64/libgrallocutils.so
 vendor/lib64/libqdMetaData.so
 vendor/lib64/libqdutils.so
 vendor/lib64/libqservice.so
+vendor/lib64/libsdedrm.so
 vendor/lib64/libsdm-colormgr-algo.so
 vendor/lib64/libsdmcore.so
 vendor/lib64/libsdmextension.so


### PR DESCRIPTION
* libsdedrm is an interface for performing atomic operations with SDE
  (Snapdragon Display Engine)

Signed-off-by: daniml3 <danimoral1001@gmail.com>