### PR TITLE
rebase_kernel.sh: Add support for .zip files

### DIFF
--- a/tools/rebase_kernel.sh
+++ b/tools/rebase_kernel.sh
@@ -41,6 +41,8 @@ elif [[ ${EXTENSION} == "tar" ]]; then
     tar -xvf ${PROJECT_DIR}/input/${FILE} -C ${PROJECT_DIR}/kernels/${UNZIP_DIR} > /dev/null 2>&1
 elif [[ ${EXTENSION} == "tbz2" ]]; then
     tar -jvxf ${PROJECT_DIR}/input/${FILE} -C ${PROJECT_DIR}/kernels/${UNZIP_DIR} > /dev/null 2>&1
+elif [[ ${EXTENSION} == "zip" ]]; then
+    unzip ${PROJECT_DIR}/input/${FILE} -d ${PROJECT_DIR}/kernels/${UNZIP_DIR} > /dev/null 2>&1    
 else
     7z x ${PROJECT_DIR}/input/${FILE} -y -o${PROJECT_DIR}/kernels/${UNZIP_DIR} > /dev/null 2>&1
 fi


### PR DESCRIPTION
## Add support for `.zip` files
Like the commit description says, OEMs like realme and Xiaomi upload their kernel sources to GitHub. Since it automatically downloads the repository as a `.zip` file, the bash script will fail in extracting files with that format. With that, users will not have to convert the file to supported file types.