### PR TITLE
rebase_kernel: Switch to CodeLinaro

### DIFF
--- a/tools/rebase_kernel.sh
+++ b/tools/rebase_kernel.sh
@@ -72,7 +72,7 @@ if [[ ! -d ${PROJECT_DIR}/kernels/msm-${KERNEL_VERSION}.${KERNEL_PATCHLEVEL} ]];
     git init -q
     git config core.fileMode false
     git config merge.renameLimit 999999
-    git remote add msm https://source.codeaurora.org/quic/la/kernel/msm-${KERNEL_VERSION}.${KERNEL_PATCHLEVEL}
+    git remote add msm https://git.codelinaro.org/clo/la/kernel/msm-${KERNEL_VERSION}.${KERNEL_PATCHLEVEL}
 fi
 
 # Create release branch


### PR DESCRIPTION
Maintained repositories have migrated to git.codelinaro.org 
and don't receive updates since March 31, 2022