### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,4 +17,5 @@ elif [[ -e "/usr/bin/pacman" ]]; then
 elif [[ -e "/usr/bin/yum" ]]; then
     sudo yum install --refresh android-tools aria2 arj brotli cabextract cmake dtc gcc git lz4 xz tinyxml2 p7zip python-pip unrar sharutils unace zip unzip uudeview zip
 fi
-pip3 install backports.lzma docopt protobuf pycrypto zstandard
+pip3 install backports.lzma docopt pycrypto zstandard
+pip3 install --force-reinstall -v "protobuf==3.20.0"


### PR DESCRIPTION
Newer protobuf fails and returns this when extracting IE latest cheetah ota

```
Traceback (most recent call last):
  File "/home/xstefen/android/android_tools/tools/Firmware_extractor/tools/extract_android_ota_payload/extract_android_ota_payload.py", line 13, in <module>
    import update_metadata_pb2
  File "/home/xstefen/android/android_tools/tools/Firmware_extractor/tools/extract_android_ota_payload/update_metadata_pb2.py", line 34, in <module>
    _descriptor.EnumValueDescriptor(
  File "/home/xstefen/.local/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 796, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
No system.img found. Exiting
```

This ensures latest functional version listed is installed instead