### PR TITLE
proprietary-files.sh: Include MTK proprietary gpu service vintf

### DIFF
--- a/tools/proprietary-files.sh
+++ b/tools/proprietary-files.sh
@@ -212,6 +212,7 @@ display_targets=(
 )
 search_blobs | get_hardware_module "${display_targets[@]}" | add_to_section Display-Hardware
 search_blobs | grep -iE "lib/|lib64/" | grep -iE "libsdm-disp-apis.so" | add_to_section Display-Hardware
+search_blobs | grep "vendor/" | grep -iE "android.hardware.gpu" | add_to_section Power-Hardware
 
 # Dolby
 search_blobs | grep "vendor/" | grep -iE "dolby" | add_to_section Dolby


### PR DESCRIPTION
* MTK has its GPU service vintf at vendor/etc/vintf/manifest/android.hardware.gpu@1.0-service.xml