### PR TITLE
Issue #27 capitalize the brand variable for the Xiaomi brand

### DIFF
--- a/helpers/rom_vars.sh
+++ b/helpers/rom_vars.sh
@@ -74,6 +74,7 @@ for var in "$@"; do
         BRAND_TEMP=$( cat "$CAT_FILE" | grep "ro.product" | grep "manufacturer=" | sed "s|.*=||g" | head -n 1 )
     fi
     BRAND=$(echo $BRAND_TEMP | tr '[:upper:]' '[:lower:]')
+    [[ "${BRAND}" == "xiaomi" ]] && BRAND="Xiaomi"
     if grep -q "ro.vivo.product.release.name" "$CAT_FILE"; then
         DEVICE=$( cat "$CAT_FILE" | grep "ro.vivo.product.release.name=" | sed "s|.*=||g" | head -n 1 )
     elif grep -q "ro.vendor.product.oem=" "$CAT_FILE"; then


### PR DESCRIPTION
---

### Summary:

This pull request resolves Issue #27 by ensuring the correct capitalization of the brand variable for Xiaomi devices. Previously, the $BRAND variable incorrectly held the value "xiaomi" instead of the standard "Xiaomi". By adding a line in `rom_vars.sh`, this issue is rectified, aligning with the expected brand representation.

### Changes Made:

- Added a line in `rom_vars.sh` to capitalize the brand variable for Xiaomi devices.

### Purpose:

The primary purpose of this pull request is to fix the capitalization inconsistency in the brand variable for Xiaomi devices. By ensuring that the $BRAND variable holds the correct capitalization, this enhancement improves code clarity and maintains consistency across the codebase, contributing to a better user experience.

### How to Test:

1. Pull the latest changes from this branch.
2. Verify that the $BRAND variable is correctly capitalized for Xiaomi devices.
3. Ensure that the fix does not introduce any regressions or unexpected behavior.

### Related Issues:

- Resolves: #27 

### Additional Notes:

This pull request adheres to the project's coding standards and has been tested to ensure proper functionality. Feedback and suggestions for further improvement are welcome.

---